### PR TITLE
Add action MO from SO

### DIFF
--- a/menghua_co/custom/sales_order.py
+++ b/menghua_co/custom/sales_order.py
@@ -1,0 +1,33 @@
+import frappe
+from frappe import _
+
+@frappe.whitelist()
+def make_manufacturing_order(source_name, target_doc=None):
+    from frappe.model.mapper import get_mapped_doc
+
+    def set_missing_values(source, target):
+        target.date = source.transaction_date  
+        target.delivery_date = source.delivery_date
+
+        for item in source.items:
+            target.append('items', {
+                'item_code': item.item_code,
+                'item_name': item.item_name,
+                'quantity': item.qty,
+                'uom': item.uom,
+            })
+
+    doclist = get_mapped_doc(
+        "Sales Order", 
+        source_name, 
+        {
+            "Sales Order": {  
+                "doctype": "Manufacturing Order", 
+            }
+        },
+        target_doc, 
+        set_missing_values, 
+    )
+
+    return doclist
+

--- a/menghua_co/public/js/sales_order.js
+++ b/menghua_co/public/js/sales_order.js
@@ -14,3 +14,17 @@ frappe.ui.form.on("Sales Order", {
         frm.refresh_field("items");
     }
 });
+
+
+frappe.ui.form.on('Sales Order', {
+    refresh(frm) {
+        frm.page.add_inner_button('Manufacturing Order', () => frm.events.make_manufacturing_order(frm), 'Create');
+    },
+
+    make_manufacturing_order: function(frm) {
+        frappe.model.open_mapped_doc({
+            method: "menghua_co.custom.sales_order.make_manufacturing_order", 
+            frm: frm
+        });
+    }
+});


### PR DESCRIPTION
From : http://redmine.ecosoft.co.th:10083/issues/5887

**Add the Manufacturing Order Action from Sales Order by adding it in the Create button.**

![MO1](https://github.com/user-attachments/assets/0b94f5c1-300d-4c1e-8319-732b62687643)

**Manufacturing Order will pull the existing data and map it for you.**

![MO2](https://github.com/user-attachments/assets/e297df95-7c7e-4f67-925c-1036f973c4d8)

