### PR TITLE
[FIX] Link of material request on work order document following MH's business flow

### DIFF
--- a/menghua_co/custom/dashboard_overrides.py
+++ b/menghua_co/custom/dashboard_overrides.py
@@ -1,7 +1,10 @@
 from frappe import _
 
+
 def get_dashboard_data_for_sales_order(data):
-    data["non_standard_fieldnames"].update({"Sales Order": "sales_order"})
+    data["non_standard_fieldnames"].update({
+        "Sales Order": "sales_order",
+    })
     for transaction in data["transactions"]:
         if transaction["label"] == _("Manufacturing"):
             transaction["items"].append("Manufacturing Order")
@@ -9,15 +12,22 @@ def get_dashboard_data_for_sales_order(data):
 
 
 def get_dashboard_data_for_work_order(data):
-    data["non_standard_fieldnames"].update({"Work Order": "work_order"})
+    data["non_standard_fieldnames"].update({
+        "Work Order": "work_order",
+    })
+    data["internal_links"].update({
+        "Material Request": "material_request",
+    })
     for transaction in data["transactions"]:
         if transaction["label"] == _("Reference"):
             transaction["items"].append("Manufacturing Order")
             return data
-        
+
 
 def get_dashboard_data_for_material_request(data):
-    data["non_standard_fieldnames"].update({"Material Request": "material_request"})
+    data["non_standard_fieldnames"].update({
+        "Material Request": "material_request",
+    })
     for transaction in data["transactions"]:
         if transaction["label"] == _("Manufacturing"):
             transaction["items"].append("Manufacturing Order")


### PR DESCRIPTION
Issue: http://redmine.ecosoft.co.th:10083/issues/5915

**Before Fix**

- Create material request => create work order
- work order is linked in material request
![image](https://github.com/user-attachments/assets/308dede1-cbc7-4ef5-adbc-028d4fbb4cf9)
- material request is **NOT** linked in work order
![image](https://github.com/user-attachments/assets/71524bbc-c387-4234-ad89-aa7bf282e843)

**After Fix**
- Create material request => create work order
- work order is linked in material request
![image](https://github.com/user-attachments/assets/045854a1-0ed0-4c34-b7e6-c202536e0bf7)
- material request is linked in work order
![image](https://github.com/user-attachments/assets/37fa9192-8ffd-43c5-b3e1-9b7546fd840e)
